### PR TITLE
Don't load html5sortable if Jui is loaded

### DIFF
--- a/Sortable.php
+++ b/Sortable.php
@@ -72,6 +72,11 @@ class Sortable extends \kartik\base\Widget
     public $items = [];
 
     /**
+     * @var bool Whether the JUI or HTML5 sortable is being used
+     */
+    public $useJui = false;
+
+    /**
      * Initializes the widget
      */
     public function init()
@@ -148,7 +153,21 @@ class Sortable extends \kartik\base\Widget
     public function registerAssets()
     {
         $view = $this->getView();
-        SortableAsset::register($view);
+        $needJui = true;
+        // Check if JUI is loaded
+        if(array_key_exists('yii\jui\JuiAsset',$view->assetBundles)) {
+            $this->useJui = true;
+            $needJui = false;
+        }
+        // Skip if JUI is loaded or passed as option
+        if($this->useJui === true) {
+            if($needJui) {
+                \yii\jui\JuiAsset::register($view);
+            }
+        }
+        else {
+            SortableAsset::register($view);
+        }
         $this->registerPlugin('sortable');
         $id = 'jQuery("#' . $this->options['id'] . '")';
         if ($this->disabled) {


### PR DESCRIPTION
Add's functionality to check if Jui is loaded.  Doesn't load the html5sortable javscript if it is.  Also addes an additional option, useJui.  This forces the widget to use Jui sortable.  Note that Jui must be registered before yii2-sortable in order for the autodetection to work.

According to the html5sortable, it is API compatible with Jui Sortable.

Fixes #15 